### PR TITLE
Update GitHub raw file URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is the Maven repository for third-party libraries not available in Maven Ce
         <enabled>false</enabled>
       </snapshots>
       <id>mvn-repo-master</id>
-      <url>https://raw.github.com/nroduit/mvn-repo/master/</url>
+      <url>https://raw.githubusercontent.com/nroduit/mvn-repo/master/</url>
     </repository>
   </repositories>
 ```


### PR DESCRIPTION
GitHub has updated the domain used to access raw files.

Old URL: https://raw.github.com/...
New URL: https://raw.githubusercontent.com/...

raw.github.com return `Error 503 hostname doesn't match against certificate`